### PR TITLE
Add a Job class

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ composer require equip/beanstalkd-consumer
 
 ## Writing Consumers
 
-A consumer is a PHP class that implements [`ConsumerInterface`](https://github.com/equip/beanstalkd-consumer/tree/master/src/ConsumerInterface.php) to process jobs received from beanstalkd, each of which is represented by an instance of the [Pheanstalk](https://github.com/pda/pheanstalk) [`Job`](https://github.com/pda/pheanstalk/blob/master/src/Job.php) class.
+A consumer is a PHP class that implements [`ConsumerInterface`](https://github.com/equip/beanstalkd-consumer/tree/master/src/ConsumerInterface.php) to process jobs received from beanstalkd, each of which is represented by an instance of the [`Job`](https://github.com/equip/beanstalkd-consumer/blob/master/src/Job.php) class.
 
 Here's an example of a consumer implementation.
 
@@ -20,7 +20,7 @@ Here's an example of a consumer implementation.
 namespace Acme;
 
 use Equip\BeanstalkConsumer\ConsumerInterface;
-use Pheanstalk\Job;
+use Equip\BeanstalkConsumer\Job;
 
 class FooConsumer implements ConsumerInterface
 {

--- a/src/ConsumerInterface.php
+++ b/src/ConsumerInterface.php
@@ -2,8 +2,6 @@
 
 namespace Equip\BeanstalkdConsumer;
 
-use Pheanstalk\Job;
-
 interface ConsumerInterface
 {
     /**

--- a/src/Daemon.php
+++ b/src/Daemon.php
@@ -87,10 +87,11 @@ class Daemon
         $consumer = call_user_func($this->resolver, $class);
 
         while (call_user_func($this->listener)) {
-            $job = $this->pheanstalk->reserve();
-            if (!$job) {
+            $reserved = $this->pheanstalk->reserve();
+            if (!$reserved) {
                 continue;
             }
+            $job = new Job($reserved->getId(), $reserved->getData());
 
             try {
                 $result = $consumer->consume($job);

--- a/src/Job.php
+++ b/src/Job.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Equip\BeanstalkdConsumer;
+
+class Job
+{
+    /**
+     * @var int
+     */
+    private $id;
+
+    /**
+     * @var string
+     */
+    private $data;
+
+    /**
+     * @param int $id
+     * @param string $data
+     */
+    public function __construct($id, $data)
+    {
+        $this->id = (int) $id;
+        $this->data = $data;
+    }
+
+    /**
+     * @return int
+     */
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    /**
+     * @return string
+     */
+    public function getData()
+    {
+        return $this->data;
+    }
+}

--- a/tests/DaemonTest.php
+++ b/tests/DaemonTest.php
@@ -8,10 +8,11 @@ use Aura\Cli\Context\Env;
 use Aura\Cli\Status;
 use Phake;
 use Relay\ResolverInterface;
-use Pheanstalk\Job;
+use Pheanstalk\Job as PheanstalkJob;
 use Pheanstalk\Pheanstalk;
 use Equip\BeanstalkdConsumer\ConsumerInterface;
 use Equip\BeanstalkdConsumer\Daemon;
+use Equip\BeanstalkdConsumer\Job;
 
 class DaemonTest extends \PHPUnit_Framework_TestCase
 {
@@ -44,6 +45,16 @@ class DaemonTest extends \PHPUnit_Framework_TestCase
      * @var string
      */
     private $tube = 'foo';
+
+    /**
+     * @var int
+     */
+    private $job_id = 2;
+
+    /**
+     * @var string
+     */
+    private $job_data = 'bar';
 
     /**
      * @var boolean
@@ -180,8 +191,10 @@ class DaemonTest extends \PHPUnit_Framework_TestCase
 
     private function getJob()
     {
-        $mock = Phake::mock(Job::class);
+        $mock = Phake::mock(PheanstalkJob::class);
+        Phake::when($mock)->getId()->thenReturn($this->job_id);
+        Phake::when($mock)->getData()->thenReturn($this->job_data);
         Phake::when($this->pheanstalk)->reserve()->thenReturn($mock);
-        return $mock;
+        return $this->isInstanceOf(Job::class);
     }
 }


### PR DESCRIPTION
Use of the Pheanstalk `Job` class in `ConsumerInterface` makes this
library a leaky abstraction with respect to its internal use of
Pheanstalk, which is an implementation detail that calling code
shouldn't need to be aware of.

This change creates a `Job` class with an equivalent API that can
wrap the data from a Pheanstalk `Job` instance. This removes the
leaky abstraction, making it possible to change the underlying
library in the future if need be.